### PR TITLE
Rename variable to fix warning

### DIFF
--- a/resource_manager/wld_file/fragments/Frag2DDmSprite.cs
+++ b/resource_manager/wld_file/fragments/Frag2DDmSprite.cs
@@ -6,7 +6,7 @@ namespace EQGodot.resource_manager.wld_file.fragments;
 [GlobalClass]
 public partial class Frag2DDmSprite : WldFragment
 {
-    [Export] public int Reference;
+    [Export] public int MeshReference;
     [Export] public Frag36DmSpriteDef2 NewMesh;
     [Export] public Frag2CDmSpriteDef OldMesh;
 
@@ -14,8 +14,8 @@ public partial class Frag2DDmSprite : WldFragment
     {
         base.Initialize(index, type, size, data, wld, loader);
         Name = wld.GetName(Reader.ReadInt32());
-        Reference = Reader.ReadInt32();
-        var fragment = wld.GetFragment(Reference);
+        MeshReference = Reader.ReadInt32();
+        var fragment = wld.GetFragment(MeshReference);
 
         NewMesh = fragment as Frag36DmSpriteDef2;
         if (NewMesh != null) return;


### PR DESCRIPTION
Just a silly change because Reference is already in use.