### PR TITLE
Point Lights need names

### DIFF
--- a/resource_manager/LoreZoneResources.cs
+++ b/resource_manager/LoreZoneResources.cs
@@ -99,9 +99,10 @@ public partial class LoreZoneResources : LoreResources
         if (_activeZoneWorldTree == null || _activeZoneLights == null) return false;
 
         sceneRoot.AddChild(_activeZoneWorldTree.ToGodotZone());
+        var count = 0;
         foreach (var l in _activeZoneLights)
         {
-            sceneRoot.AddChild(l.ToGodotLight());
+            sceneRoot.AddChild(l.ToGodotLight($"PointLight{count++}"));
         }
 
         return true;

--- a/resource_manager/interfaces/IIntoGodotLight.cs
+++ b/resource_manager/interfaces/IIntoGodotLight.cs
@@ -4,5 +4,5 @@ namespace OpenLore.resource_manager.interfaces;
 
 public interface IIntoGodotLight
 {
-    public Light3D ToGodotLight();
+    public Light3D ToGodotLight(string name);
 }

--- a/resource_manager/wld_file/fragments/Frag28PointLight.cs
+++ b/resource_manager/wld_file/fragments/Frag28PointLight.cs
@@ -23,11 +23,11 @@ public partial class Frag28PointLight : WldFragment, IIntoGodotLight
         Radius = Reader.ReadSingle();
     }
 
-    public Light3D ToGodotLight()
+    public Light3D ToGodotLight(string name)
     {
         return new OmniLight3D()
         {
-            Name = Name,
+            Name = name,
             Position = Position,
             OmniRange = Radius,
             OmniAttenuation = 0.25f,


### PR DESCRIPTION
Godot Nodes should have names that make them easier to identify, WLD Point Lights don't have one, so lets generate one. Emerald Jungle now loads with 400 errors less.